### PR TITLE
test extension with full install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,37 +2,37 @@ services:
   - docker
 
 env:
-  - TEST_GROUP=2-3-7      INTEGRATION=false
-  - TEST_GROUP=2-3-7-p1   INTEGRATION=false
-  - TEST_GROUP=2-3-7-p2   INTEGRATION=false
-  - TEST_GROUP=2-3-7-p3   INTEGRATION=false
-  - TEST_GROUP=2-3-7-p4   INTEGRATION=false
-  - TEST_GROUP=2-4-0      INTEGRATION=false
-  - TEST_GROUP=2-4-1      INTEGRATION=false
-  - TEST_GROUP=2-4-2      INTEGRATION=false
-  - TEST_GROUP=2-4-3      INTEGRATION=false
-  - TEST_GROUP=2-4-4      INTEGRATION=false
-  - TEST_GROUP=2-4-4-p1   INTEGRATION=false
-  - TEST_GROUP=2-4-4-p2   INTEGRATION=false
-  - TEST_GROUP=2-4-4-p3   INTEGRATION=false
-  - TEST_GROUP=2-4-5      INTEGRATION=false
-  - TEST_GROUP=2-4-5-p1   INTEGRATION=false
-  - TEST_GROUP=2-4-4-p2   INTEGRATION=false
-  - TEST_GROUP=2-4-6      INTEGRATION=false
-  - TEST_GROUP=2-latest   INTEGRATION=false
-  - TEST_GROUP=2-3-7      INTEGRATION=true
-  - TEST_GROUP=2-3-7-p1   INTEGRATION=true
-  - TEST_GROUP=2-3-7-p2   INTEGRATION=true
-  - TEST_GROUP=2-3-7-p3   INTEGRATION=true
-  - TEST_GROUP=2-3-7-p4   INTEGRATION=true
-  - TEST_GROUP=2-4-0      INTEGRATION=true
-  - TEST_GROUP=2-4-1      INTEGRATION=true
-  - TEST_GROUP=2-4-2      INTEGRATION=true
-  - TEST_GROUP=2-4-3      INTEGRATION=true
-  - TEST_GROUP=2-4-4      INTEGRATION=true
-  - TEST_GROUP=2-4-4-p1   INTEGRATION=true
-  - TEST_GROUP=2-4-4-p2   INTEGRATION=true
-  - TEST_GROUP=2-4-4-p3   INTEGRATION=true
+#  - TEST_GROUP=2-3-7      INTEGRATION=false
+#  - TEST_GROUP=2-3-7-p1   INTEGRATION=false
+#  - TEST_GROUP=2-3-7-p2   INTEGRATION=false
+#  - TEST_GROUP=2-3-7-p3   INTEGRATION=false
+#  - TEST_GROUP=2-3-7-p4   INTEGRATION=false
+#  - TEST_GROUP=2-4-0      INTEGRATION=false
+#  - TEST_GROUP=2-4-1      INTEGRATION=false
+#  - TEST_GROUP=2-4-2      INTEGRATION=false
+#  - TEST_GROUP=2-4-3      INTEGRATION=false
+#  - TEST_GROUP=2-4-4      INTEGRATION=false
+#  - TEST_GROUP=2-4-4-p1   INTEGRATION=false
+#  - TEST_GROUP=2-4-4-p2   INTEGRATION=false
+#  - TEST_GROUP=2-4-4-p3   INTEGRATION=false
+#  - TEST_GROUP=2-4-5      INTEGRATION=false
+#  - TEST_GROUP=2-4-5-p1   INTEGRATION=false
+#  - TEST_GROUP=2-4-4-p2   INTEGRATION=false
+#  - TEST_GROUP=2-4-6      INTEGRATION=false
+#  - TEST_GROUP=2-latest   INTEGRATION=false
+#  - TEST_GROUP=2-3-7      INTEGRATION=true
+#  - TEST_GROUP=2-3-7-p1   INTEGRATION=true
+#  - TEST_GROUP=2-3-7-p2   INTEGRATION=true
+#  - TEST_GROUP=2-3-7-p3   INTEGRATION=true
+#  - TEST_GROUP=2-3-7-p4   INTEGRATION=true
+#  - TEST_GROUP=2-4-0      INTEGRATION=true
+#  - TEST_GROUP=2-4-1      INTEGRATION=true
+#  - TEST_GROUP=2-4-2      INTEGRATION=true
+#  - TEST_GROUP=2-4-3      INTEGRATION=true
+#  - TEST_GROUP=2-4-4      INTEGRATION=true
+#  - TEST_GROUP=2-4-4-p1   INTEGRATION=true
+#  - TEST_GROUP=2-4-4-p2   INTEGRATION=true
+#  - TEST_GROUP=2-4-4-p3   INTEGRATION=true
   - TEST_GROUP=2-4-5      INTEGRATION=true
   - TEST_GROUP=2-4-5-p1   INTEGRATION=true
   - TEST_GROUP=2-4-4-p2   INTEGRATION=true
@@ -48,14 +48,15 @@ before_install:
 script:
   - shellcheck bin/*
   - shellcheck Dockerfile-assets/*.sh
-  - if [[ $INTEGRATION = false ]]; then FULL_INSTALL=1 ./bin/mtest-make $TEST_GROUP; fi
-  - if [[ $INTEGRATION = false ]]; then curl --head http://0.0.0.0:1234 | grep 200; fi
-  - if [[ $INTEGRATION = false ]]; then ./bin/mtest 'php bin/magento'; fi
-  - if [[ $INTEGRATION = true ]]; then cd tests/Ampersand_HelloWorld; fi
-  - if [[ $INTEGRATION = true ]]; then composer install --no-interaction -vvv; fi
-  - if [[ $INTEGRATION = true ]]; then CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP ; fi
-  - if [[ $INTEGRATION = true ]]; then vendor/bin/mtest 'vendor/bin/phpunit -c /var/www/html/dev/tests/unit/phpunit.xml.dist        --testsuite Unit --debug' ; fi
-  - if [[ $INTEGRATION = true ]]; then vendor/bin/mtest 'vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug' ; fi
+  - CURRENT_EXTENSION="." FULL_INSTALL=1 ./bin/mtest-make $TEST_GROUP
+  - #if [[ $INTEGRATION = false ]]; then FULL_INSTALL=1 ./bin/mtest-make $TEST_GROUP; fi
+  - #if [[ $INTEGRATION = false ]]; then curl --head http://0.0.0.0:1234 | grep 200; fi
+  - #if [[ $INTEGRATION = false ]]; then ./bin/mtest 'php bin/magento'; fi
+  - #if [[ $INTEGRATION = true ]]; then cd tests/Ampersand_HelloWorld; fi
+  - #if [[ $INTEGRATION = true ]]; then composer install --no-interaction -vvv; fi
+  - #if [[ $INTEGRATION = true ]]; then CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP ; fi
+  - #if [[ $INTEGRATION = true ]]; then vendor/bin/mtest 'vendor/bin/phpunit -c /var/www/html/dev/tests/unit/phpunit.xml.dist        --testsuite Unit --debug' ; fi
+  - #if [[ $INTEGRATION = true ]]; then vendor/bin/mtest 'vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug' ; fi
 
 after_failure:
   - docker exec mtest '/home/ampersand/assets/command.sh' 'cat /var/www/html/var/log/*.log'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,42 +2,43 @@ services:
   - docker
 
 env:
-#  - TEST_GROUP=2-3-7      INTEGRATION=false
-#  - TEST_GROUP=2-3-7-p1   INTEGRATION=false
-#  - TEST_GROUP=2-3-7-p2   INTEGRATION=false
-#  - TEST_GROUP=2-3-7-p3   INTEGRATION=false
-#  - TEST_GROUP=2-3-7-p4   INTEGRATION=false
-#  - TEST_GROUP=2-4-0      INTEGRATION=false
-#  - TEST_GROUP=2-4-1      INTEGRATION=false
-#  - TEST_GROUP=2-4-2      INTEGRATION=false
-#  - TEST_GROUP=2-4-3      INTEGRATION=false
-#  - TEST_GROUP=2-4-4      INTEGRATION=false
-#  - TEST_GROUP=2-4-4-p1   INTEGRATION=false
-#  - TEST_GROUP=2-4-4-p2   INTEGRATION=false
-#  - TEST_GROUP=2-4-4-p3   INTEGRATION=false
-#  - TEST_GROUP=2-4-5      INTEGRATION=false
-#  - TEST_GROUP=2-4-5-p1   INTEGRATION=false
-#  - TEST_GROUP=2-4-4-p2   INTEGRATION=false
-#  - TEST_GROUP=2-4-6      INTEGRATION=false
-#  - TEST_GROUP=2-latest   INTEGRATION=false
-#  - TEST_GROUP=2-3-7      INTEGRATION=true
-#  - TEST_GROUP=2-3-7-p1   INTEGRATION=true
-#  - TEST_GROUP=2-3-7-p2   INTEGRATION=true
-#  - TEST_GROUP=2-3-7-p3   INTEGRATION=true
-#  - TEST_GROUP=2-3-7-p4   INTEGRATION=true
-#  - TEST_GROUP=2-4-0      INTEGRATION=true
-#  - TEST_GROUP=2-4-1      INTEGRATION=true
-#  - TEST_GROUP=2-4-2      INTEGRATION=true
-#  - TEST_GROUP=2-4-3      INTEGRATION=true
-#  - TEST_GROUP=2-4-4      INTEGRATION=true
-#  - TEST_GROUP=2-4-4-p1   INTEGRATION=true
-#  - TEST_GROUP=2-4-4-p2   INTEGRATION=true
-#  - TEST_GROUP=2-4-4-p3   INTEGRATION=true
+  - TEST_GROUP=2-3-7      INTEGRATION=false
+  - TEST_GROUP=2-3-7-p1   INTEGRATION=false
+  - TEST_GROUP=2-3-7-p2   INTEGRATION=false
+  - TEST_GROUP=2-3-7-p3   INTEGRATION=false
+  - TEST_GROUP=2-3-7-p4   INTEGRATION=false
+  - TEST_GROUP=2-4-0      INTEGRATION=false
+  - TEST_GROUP=2-4-1      INTEGRATION=false
+  - TEST_GROUP=2-4-2      INTEGRATION=false
+  - TEST_GROUP=2-4-3      INTEGRATION=false
+  - TEST_GROUP=2-4-4      INTEGRATION=false
+  - TEST_GROUP=2-4-4-p1   INTEGRATION=false
+  - TEST_GROUP=2-4-4-p2   INTEGRATION=false
+  - TEST_GROUP=2-4-4-p3   INTEGRATION=false
+  - TEST_GROUP=2-4-5      INTEGRATION=false
+  - TEST_GROUP=2-4-5-p1   INTEGRATION=false
+  - TEST_GROUP=2-4-4-p2   INTEGRATION=false
+  - TEST_GROUP=2-4-6      INTEGRATION=false
+  - TEST_GROUP=2-latest   INTEGRATION=false
+  - TEST_GROUP=2-3-7      INTEGRATION=true
+  - TEST_GROUP=2-3-7-p1   INTEGRATION=true
+  - TEST_GROUP=2-3-7-p2   INTEGRATION=true
+  - TEST_GROUP=2-3-7-p3   INTEGRATION=true
+  - TEST_GROUP=2-3-7-p4   INTEGRATION=true
+  - TEST_GROUP=2-4-0      INTEGRATION=true
+  - TEST_GROUP=2-4-1      INTEGRATION=true
+  - TEST_GROUP=2-4-2      INTEGRATION=true
+  - TEST_GROUP=2-4-3      INTEGRATION=true
+  - TEST_GROUP=2-4-4      INTEGRATION=true
+  - TEST_GROUP=2-4-4-p1   INTEGRATION=true
+  - TEST_GROUP=2-4-4-p2   INTEGRATION=true
+  - TEST_GROUP=2-4-4-p3   INTEGRATION=true
   - TEST_GROUP=2-4-5      INTEGRATION=true
   - TEST_GROUP=2-4-5-p1   INTEGRATION=true
   - TEST_GROUP=2-4-4-p2   INTEGRATION=true
   - TEST_GROUP=2-4-6      INTEGRATION=true
   - TEST_GROUP=2-latest   INTEGRATION=true
+  - TEST_GROUP=2-latest   INTEGRATION=both
 
 before_install:
   - travis_retry wget https://github.com/docker/compose/releases/download/v2.17.0/docker-compose-linux-x86_64
@@ -48,15 +49,15 @@ before_install:
 script:
   - shellcheck bin/*
   - shellcheck Dockerfile-assets/*.sh
-  - CURRENT_EXTENSION="." FULL_INSTALL=1 ./bin/mtest-make $TEST_GROUP
-  - #if [[ $INTEGRATION = false ]]; then FULL_INSTALL=1 ./bin/mtest-make $TEST_GROUP; fi
-  - #if [[ $INTEGRATION = false ]]; then curl --head http://0.0.0.0:1234 | grep 200; fi
-  - #if [[ $INTEGRATION = false ]]; then ./bin/mtest 'php bin/magento'; fi
-  - #if [[ $INTEGRATION = true ]]; then cd tests/Ampersand_HelloWorld; fi
-  - #if [[ $INTEGRATION = true ]]; then composer install --no-interaction -vvv; fi
-  - #if [[ $INTEGRATION = true ]]; then CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP ; fi
-  - #if [[ $INTEGRATION = true ]]; then vendor/bin/mtest 'vendor/bin/phpunit -c /var/www/html/dev/tests/unit/phpunit.xml.dist        --testsuite Unit --debug' ; fi
-  - #if [[ $INTEGRATION = true ]]; then vendor/bin/mtest 'vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug' ; fi
+  - if [[ $INTEGRATION = both ]];  then CURRENT_EXTENSION="." FULL_INSTALL=1 ./bin/mtest-make $TEST_GROUP; fi
+  - if [[ $INTEGRATION = false ]]; then FULL_INSTALL=1 ./bin/mtest-make $TEST_GROUP; fi
+  - if [[ $INTEGRATION = false ]]; then curl --head http://0.0.0.0:1234 | grep 200; fi
+  - if [[ $INTEGRATION = false ]]; then ./bin/mtest 'php bin/magento'; fi
+  - if [[ $INTEGRATION = true ]]; then cd tests/Ampersand_HelloWorld; fi
+  - if [[ $INTEGRATION = true ]]; then composer install --no-interaction -vvv; fi
+  - if [[ $INTEGRATION = true ]]; then CURRENT_EXTENSION="." vendor/bin/mtest-make $TEST_GROUP ; fi
+  - if [[ $INTEGRATION = true ]]; then vendor/bin/mtest 'vendor/bin/phpunit -c /var/www/html/dev/tests/unit/phpunit.xml.dist        --testsuite Unit --debug' ; fi
+  - if [[ $INTEGRATION = true ]]; then vendor/bin/mtest 'vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug' ; fi
 
 after_failure:
   - docker exec mtest '/home/ampersand/assets/command.sh' 'cat /var/www/html/var/log/*.log'

--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,5 @@ docker-start:       # Launch docker container
 	docker compose --file=docker-compose.yml pull --quiet
 	docker compose --file=docker-compose.yml down --remove-orphans
 	docker container rm -f mtest-mysql mtest mtest-elasticsearch
-	docker compose --file=docker-compose.yml up --quiet-pull --remove-orphans -d magento --build
+	docker compose --file=docker-compose.yml up --quiet-pull --remove-orphans -d magento #--build
 	docker exec mtest '/home/ampersand/assets/magento-install.sh'

--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,5 @@ docker-start:       # Launch docker container
 	docker compose --file=docker-compose.yml pull --quiet
 	docker compose --file=docker-compose.yml down --remove-orphans
 	docker container rm -f mtest-mysql mtest mtest-elasticsearch
-	docker compose --file=docker-compose.yml up --quiet-pull --remove-orphans -d magento #--build
+	docker compose --file=docker-compose.yml up --quiet-pull --remove-orphans -d magento --build
 	docker exec mtest '/home/ampersand/assets/magento-install.sh'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     depends_on:
       - elasticsearch
       - mysql
-    #image: ampco/magento-docker-test-instance:0.1.0
+    image: ampco/magento-docker-test-instance:0.1.2
     #uncomment the below and the --build in the Makefile to test changes locally
-    build:
-      context: ./
-      dockerfile: Dockerfile
+    #build:
+    #  context: ./
+    #  dockerfile: Dockerfile
     platform: linux/amd64
     container_name: mtest
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     depends_on:
       - elasticsearch
       - mysql
-    image: ampco/magento-docker-test-instance:0.1.0
+    #image: ampco/magento-docker-test-instance:0.1.0
     #uncomment the below and the --build in the Makefile to test changes locally
-    #build:
-    #  context: ./
-    #  dockerfile: Dockerfile
+    build:
+      context: ./
+      dockerfile: Dockerfile
     platform: linux/amd64
     container_name: mtest
     volumes:


### PR DESCRIPTION
Test `CURRENT_EXTENSION="."` alongside `FULL_INSTALL=1`

When you're doing a full install with an extension theres no need to manually enable the modules. 

Moving the extension test configurations and `di:compile` until after the magento instance is installed makes more sense.