### PR TITLE
Prevent packagist lookup of `magento/*`

### DIFF
--- a/Dockerfile-assets/magento-install.sh
+++ b/Dockerfile-assets/magento-install.sh
@@ -40,11 +40,10 @@ if [ -f "/current_extension/composer.json" ]; then
   composer config "repositories.current_extension" "{\"type\": \"path\", \"canonical\":true, \"url\": \"/current_extension/\", \"options\": {\"symlink\":true}}"
   PACKAGE_NAME=$(composer config name -d /current_extension/);
   composer require "$PACKAGE_NAME":'*' --no-interaction --no-update
-  if [ "$COMPOSER_VERSION" = "composer1" ]; then
-    # prevent the module under test from being seen in packagist.org as well as local symlink
-    composer config "repositories.packagist_org" "{\"type\": \"composer\", \"url\": \"https://packagist.org\", \"exclude\": [\"$PACKAGE_NAME\"]}"
-    composer config repositories.packagist false
-  fi
+
+  # prevent the module under test from being seen in packagist.org as well as local symlink
+  composer config "repositories.packagist_org" "{\"type\": \"composer\", \"url\": \"https://packagist.org\", \"exclude\": [\"$PACKAGE_NAME\", \"magento/*\"]}"
+  composer config repositories.packagist false
 fi
 
 echo "Composer - requiring n98/magerun2"


### PR DESCRIPTION
Prevent any packagist lookups of magento deps, we use only the fooman mirror for that or other defined repository.

This should help against intermittent build fails with errors like

```
    Install of magento/module-re-captcha-admin-ui failed

  [Composer\Downloader\TransportException]
  curl error 7 while downloading https://repo.packagist.org/p2/magento/module-paypal~dev.json: Failed to connect to repo.packagist.org port 443: Connection refused

install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>]...
```

or

```
Updating dependencies (including require-dev)

  [Composer\Downloader\TransportException]
  The "https://repo.packagist.org/p/magento/module-checkout-agreements%24e267eefc269f6717199f10e12b35b7b51c28c8633d8aab2853aedf604fcda458.json" file could not be downloaded: failed to open stream: Cannot assign requested address
```