### PR TITLE
[WIP] Xdebug support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,12 @@ RUN rm /var/www/html/index.html && chown -R ampersand:www-data /var/www/html && 
 
 RUN sed -i 's/nobody/ampersand/' /home/ampersand/.phpenv/versions/8.2.2/etc/php-fpm.d/www.conf && sed -i 's/nobody/ampersand/' /home/ampersand/.phpenv/versions/8.1.6/etc/php-fpm.d/www.conf && sed -i 's/nobody/ampersand/' /home/ampersand/.phpenv/versions/7.4.29/etc/php-fpm.d/www.conf
 
-# Disable xdebug for performance
-RUN rm /home/ampersand/.phpenv/versions/*/etc/conf.d/xdebug.ini
-
 RUN a2enmod rewrite actions alias headers proxy proxy_fcgi proxy_http expires ssl
 
 WORKDIR /home/ampersand
 USER ampersand
+
+# Disable xdebug for performance
+RUN for ver in $(phpenv versions --bare); do printf "\nxdebug.mode=debug\nxdebug.client_host=docker.for.mac.localhost\nxdebug.client_port=901\nxdebug.idekey=PHPSTORM\n" >> /home/ampersand/.phpenv/versions/$ver/etc/conf.d/xdebug.ini ; done
+RUN for ver in $(phpenv versions --bare); do mkdir /home/ampersand/.phpenv/versions/$ver/etc/conf.d_disabled/; done
+RUN for ver in $(phpenv versions --bare); do mv /home/ampersand/.phpenv/versions/$ver/etc/conf.d/xdebug.ini /home/ampersand/.phpenv/versions/$ver/etc/conf.d_disabled/; done

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ WORKDIR /home/ampersand
 USER ampersand
 
 # Disable xdebug for performance
-RUN for ver in $(phpenv versions --bare); do printf "\nxdebug.mode=debug\nxdebug.client_host=docker.for.mac.localhost\nxdebug.client_port=901\nxdebug.idekey=PHPSTORM\n" >> /home/ampersand/.phpenv/versions/$ver/etc/conf.d/xdebug.ini ; done
+RUN for ver in $(phpenv versions --bare); do printf "\nxdebug.mode=debug\nxdebug.client_host=docker.for.mac.localhost\nxdebug.client_port=9010\nxdebug.idekey=PHPSTORM\n" >> /home/ampersand/.phpenv/versions/$ver/etc/conf.d/xdebug.ini ; done
 RUN for ver in $(phpenv versions --bare); do mkdir /home/ampersand/.phpenv/versions/$ver/etc/conf.d_disabled/; done
 RUN for ver in $(phpenv versions --bare); do mv /home/ampersand/.phpenv/versions/$ver/etc/conf.d/xdebug.ini /home/ampersand/.phpenv/versions/$ver/etc/conf.d_disabled/; done

--- a/README.md
+++ b/README.md
@@ -83,3 +83,12 @@ We have the following environment variables which can be overridden when running
  | `COMPOSER_REQUIRE_EXTRA` |                                               | `COMPOSER_REQUIRE_EXTRA='some/suggested-module another/suggested-module' vendor/bin/mtest-make 2-4-5` |
  | `COMPOSER_AFTER_INSTALL_COMMAND` |                                               | `COMPOSER_AFTER_INSTALL_COMMAND='cp foo.txt bar.txt' vendor/bin/mtest-make 2-4-5`                     | 
  | `TWOFACTOR_ENABLED` | 0 | Whether the magento 2fa modules are enabled by default, can be `1` or `0`                    |
+
+# XDEBUG
+
+```bash
+# this will allow xdebug on port 9010 and docker.for.mac.localhost
+./vendor/bin/mtest-enable-xdebug 
+```
+
+You can configure in the docker container `/home/ampersand/.phpenv/versions/*/etc/conf.d/xdebug.ini` for your own set up, preconfigured for use at Ampersand.

--- a/bin/mtest-enable-xdebug
+++ b/bin/mtest-enable-xdebug
@@ -1,0 +1,6 @@
+#!/bin/bash
+if ! docker exec mtest '/home/ampersand/assets/command.sh' 'php --ini | grep xdebug'; then
+  echo "enabling xdebug"
+  docker exec mtest '/home/ampersand/assets/command.sh' 'for ver in $(phpenv versions --bare); do mv /home/ampersand/.phpenv/versions/$ver/etc/conf.d_disabled/xdebug.ini /home/ampersand/.phpenv/versions/$ver/etc/conf.d/; done'
+fi
+docker exec mtest '/home/ampersand/assets/command.sh' 'php --ini | grep xdebug'

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "bin": [
     "bin/mtest",
     "bin/mtest-make",
-    "bin/mtest-ssh"
+    "bin/mtest-ssh",
+    "bin/mtest-enable-xdebug"
   ],
   "description": "A dev dependency helper to set up a magento instance, to be used for testing modules",
   "license": "LGPL-3.0-only"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - elasticsearch
       - mysql
-    image: ampco/magento-docker-test-instance:0.1.5
+    image: ampco/magento-docker-test-instance:0.1.13
     #uncomment the below and the --build in the Makefile to test changes locally
     #build:
     #  context: ./


### PR DESCRIPTION
# Setup

1. Set `Run -> Break at first line in php scripts` in phpstorm to get it to catch everywhere, this can be turned off later once you've got it set up okay.
2. Go into phpstorm settings and 
    1. listens for xdebug on your OSX port `9010`
    1. create a `Server` called `DockerServer`. You'll see an option to set up mappings, configure it

![Screenshot 2023-06-22 at 14 25 48](https://github.com/AmpersandHQ/magento-docker-test-instance/assets/600190/3154459e-3b21-442c-a049-3ebca062bd71)

# Usage 

1. In phpstorm start listening for xdebug connections.
2. Run `./vendor/bin/mtest-enable-xdebug`

3. You can debug random files like

```
./vendor/bin/mtest 'PHP_IDE_CONFIG="serverName=DockerServer" XDEBUG_CONFIG=1 php vendor/ampersand/your-module/example.php'
```

4. So you could debug an integration test like

```
vendor/bin/mtest 'PHP_IDE_CONFIG="serverName=DockerServer" XDEBUG_CONFIG=1 vendor/bin/phpunit -c /var/www/html/dev/tests/integration/phpunit.xml.dist --testsuite Integration --debug --filter TestNameHere'
```

You may need to skip certain parts of the code, or configure a path mapping from your local instance to the docker container, you can hit "play" to skip pieces. This may prevent you from stepping "into" some code.

![Screenshot 2023-06-22 at 14 29 53](https://github.com/AmpersandHQ/magento-docker-test-instance/assets/600190/9ac8465b-5f87-4250-99dd-0b3ade461bc9)



## Notes

You should be able to make changes locally and that will sync up properly with the docker container, so your breakpoints and code locally should be in sync with the container.

## TODO 

Look up options of phpstorm remote server setup and debugging. Possibly we can open phpstorm with the entire docker `/var/www/html` and be able to xdebug in there.