### PR TITLE
Fix integration tests for 2.4.6-p2

### DIFF
--- a/Dockerfile-assets/magento-install.sh
+++ b/Dockerfile-assets/magento-install.sh
@@ -138,7 +138,7 @@ if [ -f "/current_extension/composer.json" ]; then
   php /home/ampersand/assets/prepare-phpunit-config.php /var/www/html "$(composer config name -d /current_extension/)" "$INTEGRATION_TESTS_PATH" "$UNIT_TESTS_PATH"
   php bin/magento setup:di:compile
 
-  if [[ "$MAGE_VERSION" == 2.4.3 ]] || [[ "$MAGE_VERSION" == 2.4.4* ]] || [[ "$MAGE_VERSION" == 2.4.5* ]] || [[ "$MAGE_VERSION" == 2.4.7* ]]; then
+  if [[ "$MAGE_VERSION" == 2.4.3 ]] || [[ "$MAGE_VERSION" == 2.4.4* ]] || [[ "$MAGE_VERSION" == 2.4.5* ]] || [[ "$MAGE_VERSION" == 2.4.7* ]] || [[ "$MAGE_VERSION" == 2.4.6-p2 ]]; then
     # Re-running the install process seems to fix this issue https://github.com/magento/magento2/issues/33802
     composer install --no-interaction
   fi


### PR DESCRIPTION
The installer would fail during the test runner

```
Disabling Maintenance Mode:
In ResourceConnection.php line 148:
  [DomainException]
  Connection "default" is not defined
Exception trace:
  at /var/www/html/vendor/magento/framework/App/ResourceConnection.php:148
  ```