### PR TITLE
Fix `2.4.6-p2` handling as `2-latest`

### DIFF
--- a/Dockerfile-assets/magento-install.sh
+++ b/Dockerfile-assets/magento-install.sh
@@ -79,6 +79,11 @@ else
   false
 fi
 
+if [ "$MAGE_VERSION" = "0" ]; then
+  # allows us to handle edge cases in latest version by version number
+  MAGE_VERSION=$(php bin/magento --version | awk '{ print $3 }')
+fi
+
 if [ ! "$COMPOSER_AFTER_INSTALL_COMMAND" = "0" ]; then
   echo "running after install command $COMPOSER_AFTER_INSTALL_COMMAND"
   eval "$COMPOSER_AFTER_INSTALL_COMMAND"


### PR DESCRIPTION
When we install 2.4.6-p2 as the latest version then the env var `MAGE_VERSION` is not set, so we cannot trigger our conditional handling fixes down below.

This way we will have this environment variable updated with the relevant contents of this command
```
$ php bin/magento --version
Magento CLI 2.4.6-p2
```