### PR TITLE
Move `MAGE_VERSION` handling

### DIFF
--- a/Dockerfile-assets/magento-install.sh
+++ b/Dockerfile-assets/magento-install.sh
@@ -142,6 +142,11 @@ if [ -f "/current_extension/composer.json" ]; then
   fi
   php /home/ampersand/assets/prepare-phpunit-config.php /var/www/html "$(composer config name -d /current_extension/)" "$INTEGRATION_TESTS_PATH" "$UNIT_TESTS_PATH"
   php bin/magento setup:di:compile
+  if [ ! "$FULL_INSTALL" -eq "1" ]; then
+    echo "Removing app/etc/env.php"
+    cat app/etc/env.php
+    rm -f app/etc/env.php # https://github.com/magento/magento2/issues/37805#issuecomment-1658555063
+  fi
 
   if [[ "$MAGE_VERSION" == 2.4.3 ]] || [[ "$MAGE_VERSION" == 2.4.4* ]] || [[ "$MAGE_VERSION" == 2.4.5* ]] || [[ "$MAGE_VERSION" == 2.4.7* ]] || [[ "$MAGE_VERSION" == 2.4.6-p2 ]]; then
     # Re-running the install process seems to fix this issue https://github.com/magento/magento2/issues/33802

--- a/Dockerfile-assets/magento-install.sh
+++ b/Dockerfile-assets/magento-install.sh
@@ -79,11 +79,6 @@ else
   false
 fi
 
-if [ "$MAGE_VERSION" = "0" ]; then
-  # allows us to handle edge cases in latest version by version number
-  MAGE_VERSION=$(php bin/magento --version | awk '{ print $3 }')
-fi
-
 if [ ! "$COMPOSER_AFTER_INSTALL_COMMAND" = "0" ]; then
   echo "running after install command $COMPOSER_AFTER_INSTALL_COMMAND"
   eval "$COMPOSER_AFTER_INSTALL_COMMAND"
@@ -134,6 +129,11 @@ elif [ -f "/current_extension/composer.json" ]; then
 fi
 
 if [ -f "/current_extension/composer.json" ]; then
+  if [ "$MAGE_VERSION" = "0" ]; then
+    # allows us to handle edge cases in latest version by version number
+    MAGE_VERSION=$(php bin/magento --version | awk '{ print $3 }')
+  fi
+
   echo "Configuring current extension for integration tests"
   mysql -hdatabase -uroot -e "create database if not exists magento_integration_tests"
   cp /home/ampersand/assets/install-config-mysql.php.dist dev/tests/integration/etc/install-config-mysql.php

--- a/Dockerfile-assets/magento-install.sh
+++ b/Dockerfile-assets/magento-install.sh
@@ -142,11 +142,6 @@ if [ -f "/current_extension/composer.json" ]; then
   fi
   php /home/ampersand/assets/prepare-phpunit-config.php /var/www/html "$(composer config name -d /current_extension/)" "$INTEGRATION_TESTS_PATH" "$UNIT_TESTS_PATH"
   php bin/magento setup:di:compile
-  if [ ! "$FULL_INSTALL" -eq "1" ]; then
-    echo "Removing app/etc/env.php"
-    cat app/etc/env.php
-    rm -f app/etc/env.php # https://github.com/magento/magento2/issues/37805#issuecomment-1658555063
-  fi
 
   if [[ "$MAGE_VERSION" == 2.4.3 ]] || [[ "$MAGE_VERSION" == 2.4.4* ]] || [[ "$MAGE_VERSION" == 2.4.5* ]] || [[ "$MAGE_VERSION" == 2.4.7* ]] || [[ "$MAGE_VERSION" == 2.4.6-p2 ]]; then
     # Re-running the install process seems to fix this issue https://github.com/magento/magento2/issues/33802


### PR DESCRIPTION
So that we only call `bin/magento` as late in the game as possible.

on a repo doing tasks in `COMPOSER_AFTER_INSTALL_COMMAND` we were seeing oddities because the call to `bin/magento` was warming some generation earlier than expected.