### PR TITLE
Fix 2.4.4

### DIFF
--- a/Dockerfile-assets/magento-install.sh
+++ b/Dockerfile-assets/magento-install.sh
@@ -54,7 +54,7 @@ else
 fi
 
 echo "Composer - requiring n98/magerun2"
-composer require n98/magerun2:"*" --dev --no-interaction --no-update
+composer require n98/magerun2-dist:"*" --dev --no-interaction --no-update
 
 if [ ! "$COMPOSER_REQUIRE_EXTRA" = "0" ]; then
   echo "Composer - requiring $COMPOSER_REQUIRE_EXTRA"


### PR DESCRIPTION
The newer 2.4.7 functionality is getting pulled in to the old 2.4.4 series, failing di compilation. see https://app.travis-ci.com/github/AmpersandHQ/magento2-log-correlation-id/jobs/620977882

~The 2-latest series are failing because of https://github.com/netz98/n98-magerun2/issues/1454, so that shouldn't prevent this being merged in and they should start going green when magerun2 is updated.~